### PR TITLE
Add KuruAPI to __init__.py

### DIFF
--- a/kuru_sdk/__init__.py
+++ b/kuru_sdk/__init__.py
@@ -2,6 +2,7 @@ from .orderbook import Orderbook, TxOptions, MarketParams
 from .margin import MarginAccount
 from .client_order_executor import ClientOrderExecutor
 from .types import OrderRequest
+from .api import KuruAPI
 
 
 __version__ = "0.1.0"
@@ -13,4 +14,5 @@ __all__ = [
     'MarginAccount',
     'ClientOrderExecutor',
     'OrderRequest',
+    'KuruAPI'
 ]

--- a/kuru_sdk/margin.py
+++ b/kuru_sdk/margin.py
@@ -76,7 +76,7 @@ class MarginAccount:
                 print("Approving tokens for deposit...")
                 allowance_tx = token_contract.functions.approve(self.contract_address, amount).build_transaction({
                     'from': self.wallet_address,
-                    'nonce': self.web3.eth.get_transaction_count(self.wallet_address),
+                    'nonce': self.web3.eth.get_transaction_count(self.wallet_address, "pending"),
                 })
                 signed_tx = self.web3.eth.account.sign_transaction(allowance_tx, self.private_key)
                 tx_hash = self.web3.eth.send_raw_transaction(signed_tx.raw_transaction)
@@ -95,7 +95,7 @@ class MarginAccount:
         
         # Get gas estimate and nonce
         gas_estimate = transaction.estimate_gas({'from': self.wallet_address, 'value': value})
-        nonce = self.web3.eth.get_transaction_count(self.wallet_address)
+        nonce = self.web3.eth.get_transaction_count(self.wallet_address, "pending")
         
         # Build transaction dict
         transaction_dict = {
@@ -146,7 +146,7 @@ class MarginAccount:
         
         # Get gas estimate and nonce
         gas_estimate = transaction.estimate_gas({'from': self.wallet_address})
-        nonce = self.web3.eth.get_transaction_count(self.wallet_address)
+        nonce = self.web3.eth.get_transaction_count(self.wallet_address, "pending")
         
         # Build transaction dict
         transaction_dict = {


### PR DESCRIPTION
The KuruAPI class is missing from __init__.py. As a result, it will not be imported with the other SDK classes in the event of a wildcard import.